### PR TITLE
Fix WooCommerce version key in system status endpoint

### DIFF
--- a/source/includes/wp-api-v2/_system-status.md
+++ b/source/includes/wp-api-v2/_system-status.md
@@ -20,7 +20,7 @@ The system status API allows you to view all system status items.
 | --------------------------- | ------- | -------------------------------------------------------------------------- |
 | `home_url`                  | string  | Home URL. <i class="label label-info">read-only</i>                        |
 | `site_url`                  | string  | Site URL. <i class="label label-info">read-only</i>                        |
-| `wc_version`                | string  | WooCommerce version. <i class="label label-info">read-only</i>             |
+| `version`                   | string  | WooCommerce version. <i class="label label-info">read-only</i>             |
 | `log_directory`             | string  | Log directory. <i class="label label-info">read-only</i>                   |
 | `log_directory_writable`    | boolean | Is log directory writable? <i class="label label-info">read-only</i>       |
 | `wp_version`                | string  | WordPress version. <i class="label label-info">read-only</i>               |

--- a/source/includes/wp-api-v3/_system-status.md
+++ b/source/includes/wp-api-v3/_system-status.md
@@ -20,7 +20,7 @@ The system status API allows you to view all system status items.
 | --------------------------- | ------- | -------------------------------------------------------------------------- |
 | `home_url`                  | string  | Home URL. <i class="label label-info">read-only</i>                        |
 | `site_url`                  | string  | Site URL. <i class="label label-info">read-only</i>                        |
-| `wc_version`                | string  | WooCommerce version. <i class="label label-info">read-only</i>             |
+| `version`                   | string  | WooCommerce version. <i class="label label-info">read-only</i>             |
 | `log_directory`             | string  | Log directory. <i class="label label-info">read-only</i>                   |
 | `log_directory_writable`    | boolean | Is log directory writable? <i class="label label-info">read-only</i>       |
 | `wp_version`                | string  | WordPress version. <i class="label label-info">read-only</i>               |


### PR DESCRIPTION
According to the code (https://github.com/woocommerce/woocommerce/blame/trunk/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php), the field containing WooCommerce version has always been `version` and not `wc_version` as documented.